### PR TITLE
Fix report collection error.

### DIFF
--- a/app/src/main/java/com/app/bugapp/AdbConnection.kt
+++ b/app/src/main/java/com/app/bugapp/AdbConnection.kt
@@ -73,7 +73,10 @@ class AdbConnection (private val context: Context)  {
                 return Pair(true, localFilename)
             }
         }
-        catch (ignore : Throwable) { }
+        catch (e : Throwable) {
+            Log.e(tag, "Exception in ${::bugreport.name}: ${e.message}")
+            e.printStackTrace()
+        }
         return Pair(false, "")
     }
 }

--- a/app/src/main/java/com/app/bugapp/MainActivity.kt
+++ b/app/src/main/java/com/app/bugapp/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : ComponentActivity() {
                         label = { Text(text = "IP address") },
                     )
                     OutlinedTextField(
-                        value = port.value.toString(),
+                        value = port.value.toString().trim(),
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                         singleLine = true,
                         onValueChange = {port.value = it.toInt()


### PR DESCRIPTION
If user press Enter after providing address in Emulator then bugreport collection fails with "java.net.UnknownHostException: Unable to resolve host .." due to whitespace characters in the end of address string.